### PR TITLE
Add the ability to use traps as filler

### DIFF
--- a/worlds/_manual/Items.py
+++ b/worlds/_manual/Items.py
@@ -10,10 +10,10 @@ progressive_item_table = before_progressive_item_table_processed(progressive_ite
 # Generate item lookups
 ######################
 
-item_id_to_name = {}
-item_name_to_item = {}
-item_name_groups = {}
-advancement_item_names = set()
+item_id_to_name: dict[int, str] = {}
+item_name_to_item: dict[str, dict] = {}
+item_name_groups: dict[str, str] = {}
+advancement_item_names: set[str] = set()
 lastItemId = -1
 
 count = starting_index

--- a/worlds/_manual/Options.py
+++ b/worlds/_manual/Options.py
@@ -3,9 +3,12 @@ from Options import FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, Te
 from .hooks.Options import before_options_defined, after_options_defined
 
 
+class FillerTrapPercent(Range):
+    """How many fillers will be replaced with traps. 0 means no additional traps, 100 means all fillers are traps."""
+    range_end = 100
 
 manual_options = before_options_defined({})
 
-# Manual can do things to define options here, though it doesn't currently
+manual_options["filler_traps"] = FillerTrapPercent
 
 manual_options = after_options_defined(manual_options)

--- a/worlds/_manual/Rules.py
+++ b/worlds/_manual/Rules.py
@@ -76,7 +76,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
 
             item_parts = item.split(":")
             item_name = item
-            item_count = 1
+            item_count = "1"
 
             if len(item_parts) > 1:
                 item_name = item_parts[0]
@@ -167,31 +167,31 @@ def set_rules(base: World, world: MultiWorld, player: int):
         # if it's not a usable object of some sort, default to true
         if not area:
             return True
-        
+
         # don't require the "requires" key for locations and regions if they don't need to use it
         if "requires" not in area.keys():
             return True
-        
+
         if isinstance(area["requires"], str):
             return checkRequireStringForArea(state, area)
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
-    
+
     # Region access rules
     for region in regionMap.keys():
         if region != "Menu":
             for exitRegion in world.get_region(region, player).exits:
                 def fullRegionCheck(state, region=regionMap[region]):
                     return fullLocationOrRegionCheck(state, region)
-                
-                set_rule(world.get_entrance(exitRegion.name, player), fullRegionCheck)    
+
+                set_rule(world.get_entrance(exitRegion.name, player), fullRegionCheck)
 
     # Location access rules
     for location in base.location_table:
         locFromWorld = world.get_location(location["name"], player)
 
         locationRegion = regionMap[location["region"]] if "region" in location else None
-        
+
         if "requires" in location: # Location has requires, check them alongside the region requires
             def checkBothLocationAndRegion(state, location=location, region=locationRegion):
                 locationCheck = fullLocationOrRegionCheck(state, location)
@@ -201,17 +201,17 @@ def set_rules(base: World, world: MultiWorld, player: int):
                     regionCheck = fullLocationOrRegionCheck(state, region)
 
                 return locationCheck and regionCheck
-            
+
             set_rule(locFromWorld, checkBothLocationAndRegion)
         elif "region" in location: # Only region access required, check the location's region's requires
             def fullRegionCheck(state, region=locationRegion):
                 return fullLocationOrRegionCheck(state, region)
-            
+
             set_rule(locFromWorld, fullRegionCheck)
         else: # No location region and no location requires? It's accessible.
             def allRegionsAccessible(state):
                 return True
-            
+
             set_rule(locFromWorld, allRegionsAccessible)
 
     # Victory requirement


### PR DESCRIPTION
## What is this fixing or adding?
This lets the generator pull from traps instead of filler, and it adds a yaml option to determine how many of the fillers should be replaced this way.


## How was this tested?

Tested with yamls at 0/50/100 trap percent with an items.json that defined a trap with `count: 0`.