### PR TITLE
manual_unstable: Add `dev_category` as a json option

### DIFF
--- a/worlds/_manual/Data.py
+++ b/worlds/_manual/Data.py
@@ -4,6 +4,7 @@ import pkgutil
 import sys
 
 from .DataValidation import DataValidation, ValidationError
+from .Helpers import category_join
 
 from .hooks.Data import \
     after_load_item_file, after_load_progressive_item_file, \
@@ -26,6 +27,11 @@ item_table = load_data_file('items.json')
 progressive_item_table = {}
 location_table = load_data_file('locations.json')
 region_table = load_data_file('regions.json')
+
+# create all_categories
+item_table = category_join(item_table)
+progressive_item_table = category_join(progressive_item_table)
+location_table = category_join(location_table)
 
 # hooks
 item_table = after_load_item_file(item_table)

--- a/worlds/_manual/DataValidation.py
+++ b/worlds/_manual/DataValidation.py
@@ -256,7 +256,7 @@ class DataValidation():
             
             if "item_categories" in starting_block:
                 for category_name in starting_block["item_categories"]:
-                    if len([item for item in DataValidation.item_table if "category" in item and category_name in item["category"]]) == 0:
+                    if len([item for item in DataValidation.item_table if "all_category" in item and category_name in item["all_category"]]) == 0:
                         raise ValidationError("Item category %s is set as a starting item category, but is misspelled or is not defined on any items." % (category_name))
 
     @staticmethod

--- a/worlds/_manual/Helpers.py
+++ b/worlds/_manual/Helpers.py
@@ -16,3 +16,4 @@ def category_join(table: List[Dict[str, any]]):
     for item in table:
         if len({'category', 'dev_category'}.intersection(item.keys())):
             item['all_category'] = item.get('category', []) + item.get('dev_category', [])
+    return table

--- a/worlds/_manual/Helpers.py
+++ b/worlds/_manual/Helpers.py
@@ -1,6 +1,6 @@
 from BaseClasses import MultiWorld
 
-from typing import Union
+from typing import Union, List, Dict
 
 def is_option_enabled(world: MultiWorld, player: int, name: str) -> bool:
     return get_option_value(world, player, name) > 0
@@ -11,3 +11,8 @@ def get_option_value(world: MultiWorld, player: int, name: str) -> Union[int, di
         return 0
 
     return option[player].value
+
+def category_join(table: List[Dict[str, any]]):
+    for item in table:
+        if len({'category', 'dev_category'}.intersection(item.keys())):
+            item['all_category'] = item.get('category', []) + item.get('dev_category', [])

--- a/worlds/_manual/Items.py
+++ b/worlds/_manual/Items.py
@@ -40,7 +40,7 @@ for item in item_table:
     if item["id"] is not None:
         lastItemId = max(lastItemId, item["id"])
 
-    for c in item.get("category", []):
+    for c in item.get("all_category", []):
         if c not in item_name_groups:
             item_name_groups[c] = []
         item_name_groups[c].append(item_name)

--- a/worlds/_manual/Locations.py
+++ b/worlds/_manual/Locations.py
@@ -48,7 +48,7 @@ for item in location_table:
     location_id_to_name[item["id"]] = item["name"]
     location_name_to_location[item["name"]] = item
 
-    for c in item.get("category", []):
+    for c in item.get("all_category", []):
         if c not in location_name_groups:
             location_name_groups[c] = []
         location_name_groups[c].append(item["name"])

--- a/worlds/_manual/Rules.py
+++ b/worlds/_manual/Rules.py
@@ -85,7 +85,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
             total = 0
 
             if require_type == 'category':
-                category_items = [item for item in base.item_name_to_item.values() if "category" in item and item_name in item["category"]]
+                category_items = [item for item in base.item_name_to_item.values() if "all_category" in item and item_name in item["all_category"]]
                 if item_count.lower() == 'all':
                     item_count = sum([base.item_name_to_item[category_item["name"]]['count'] for category_item in category_items])
                 elif item_count.lower() == 'half':

--- a/worlds/_manual/__init__.py
+++ b/worlds/_manual/__init__.py
@@ -139,7 +139,7 @@ class ManualWorld(World):
 
                 # if the setting lists specific item categories, limit the items to ones that have any of those categories
                 if "item_categories" in starting_item_block:
-                    items_in_categories = [item["name"] for item in self.item_name_to_item.values() if "category" in item and len(set(starting_item_block["item_categories"]).intersection(item["category"])) > 0]
+                    items_in_categories = [item["name"] for item in self.item_name_to_item.values() if "all_category" in item and len(set(starting_item_block["item_categories"]).intersection(item["all_category"])) > 0]
                     items = [item for item in pool if item.name in items_in_categories]
 
                 random.shuffle(items)
@@ -185,7 +185,7 @@ class ManualWorld(World):
                 if len(location["place_item_category"]) == 0:
                     continue
 
-                eligible_item_names = [i["name"] for i in item_name_to_item.values() if "category" in i and set(i["category"]).intersection(location["place_item_category"])]
+                eligible_item_names = [i["name"] for i in item_name_to_item.values() if "all_category" in i and set(i["all_category"]).intersection(location["place_item_category"])]
                 eligible_items = [item for item in self.multiworld.itempool if item.name in eligible_item_names and item.player == self.player]
 
                 if len(eligible_items) == 0:

--- a/worlds/_manual/data/items.json
+++ b/worlds/_manual/data/items.json
@@ -69,6 +69,9 @@
             "Characters",
             "Right Side"
         ],
+        "dev_category": [
+            "Avengers"
+        ],
         "progression": true 
     },
     { 
@@ -132,6 +135,9 @@
         "category": [
             "Characters",
             "Right Side"
+        ],
+        "dev_category": [
+            "Avengers"
         ],
         "progression": true 
     },
@@ -197,6 +203,9 @@
             "Characters",
             "Right Side"
         ],
+        "dev_category": [
+            "Avengers"
+        ],
         "progression": true 
     },
     { 
@@ -261,6 +270,9 @@
             "Characters",
             "Right Side"
         ],
+        "dev_category": [
+            "Avengers"
+        ],
         "progression": true 
     },
     { 
@@ -309,6 +321,9 @@
             "Characters",
             "Right Side"
         ],
+        "dev_category": [
+            "Avengers"
+        ],
         "progression": true 
     },
     { 
@@ -324,6 +339,9 @@
         "category": [
             "Characters",
             "Right Side"
+        ],
+        "dev_category": [
+            "Avengers"
         ],
         "progression": true 
     },

--- a/worlds/_manual/data/locations.json
+++ b/worlds/_manual/data/locations.json
@@ -63,7 +63,8 @@
     { 
         "name": "Beat the Game - Doctor Strange", 
         "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Doctor Strange|"
+        "requires": "|Doctor Strange|",
+        "place_item_category": ["Avengers"]
     },
     { 
         "name": "Beat the Game - Chris", 

--- a/worlds/_manual/data/locations.json
+++ b/worlds/_manual/data/locations.json
@@ -99,7 +99,7 @@
     { 
         "name": "Beat the Game - Captain America", 
         "category": ["Unlocked Teams", "Right Side"],
-        "requires": "|Captain America|"
+        "requires": "|Captain America| AND |@Avengers:3|"
     },
     { 
         "name": "Beat the Game - Dormammu", 


### PR DESCRIPTION
## What is this fixing or adding?

Adds `dev_category` as a json option. This is treated as a normal `category` for internal logic, but will not be displayed to the client. This allows you to use lots of categories for special access rules or custom `place_item_category` settings without cluttering up the UI.

## How was this tested?

Multiple local generations

## If this makes graphical changes, please attach screenshots.

N/A
