### PR TITLE
Category settings

### DIFF
--- a/worlds/_manual/Data.py
+++ b/worlds/_manual/Data.py
@@ -25,7 +25,7 @@ item_table = load_data_file('items.json')
 progressive_item_table = {}
 location_table = load_data_file('locations.json')
 region_table = load_data_file('regions.json')
-category_table = load_data_file('categories.json')
+category_table = load_data_file('categories.json') or {}
 
 # hooks
 item_table = after_load_item_file(item_table)

--- a/worlds/_manual/Data.py
+++ b/worlds/_manual/Data.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pkgutil
-import sys
 
 from .DataValidation import DataValidation, ValidationError
 
@@ -26,6 +25,7 @@ item_table = load_data_file('items.json')
 progressive_item_table = {}
 location_table = load_data_file('locations.json')
 region_table = load_data_file('regions.json')
+category_table = load_data_file('categories.json')
 
 # hooks
 item_table = after_load_item_file(item_table)

--- a/worlds/_manual/Helpers.py
+++ b/worlds/_manual/Helpers.py
@@ -16,8 +16,8 @@ def get_option_value(world: MultiWorld, player: int, name: str) -> Union[int, di
 def is_category_enabled(world: MultiWorld, player: int, category_name: str) -> bool:
     """Check if a category has been disabled by a yaml option."""
     category_data = category_table.get(category_name, {})
-    if "requires_yaml" in category_data:
-        for option_name in category_data["requires_yaml"]:
+    if "yaml_option" in category_data:
+        for option_name in category_data["yaml_option"]:
             if not is_option_enabled(world, player, option_name):
                 return False
     return True

--- a/worlds/_manual/Helpers.py
+++ b/worlds/_manual/Helpers.py
@@ -1,4 +1,5 @@
 from BaseClasses import MultiWorld
+from .Data import category_table
 
 from typing import Union
 
@@ -11,3 +12,12 @@ def get_option_value(world: MultiWorld, player: int, name: str) -> Union[int, di
         return 0
 
     return option[player].value
+
+def is_category_enabled(world: MultiWorld, player: int, category_name: str) -> bool:
+    """Check if a category has been disabled by a yaml option."""
+    category_data = category_table.get(category_name, {})
+    if "requires_yaml" in category_data:
+        for option_name in category_data["requires_yaml"]:
+            if not is_option_enabled(world, player, option_name):
+                return False
+    return True

--- a/worlds/_manual/ManualClient.py
+++ b/worlds/_manual/ManualClient.py
@@ -38,6 +38,7 @@ class ManualContext(SuperContext):
     location_table = {}
     item_table = {}
     region_table = {}
+    category_table = {}
 
     tracker_reachable_locations = []
 
@@ -256,6 +257,9 @@ class ManualContext(SuperContext):
                 for item in self.ctx.item_table.values() or AutoWorldRegister.world_types[self.ctx.game].item_name_to_item.values():
                     if "category" in item and len(item["category"]) > 0:
                         for category in item["category"]:
+                            category_settings = self.ctx.category_table.get(category) or getattr(AutoWorldRegister.world_types[self.ctx.game], "category_table", {}).get(category, {})
+                            if "hidden" in category_settings and category_settings["hidden"]:
+                                continue
                             if category not in self.item_categories:
                                 self.item_categories.append(category)
 
@@ -278,6 +282,9 @@ class ManualContext(SuperContext):
 
                     if "category" in location and len(location["category"]) > 0:
                         for category in location["category"]:
+                            category_settings = self.ctx.category_table.get(category) or getattr(AutoWorldRegister.world_types[self.ctx.game], "category_table", {}).get(category, {})
+                            if "hidden" in category_settings and category_settings["hidden"]:
+                                continue
                             if category not in self.location_categories:
                                 self.location_categories.append(category)
 
@@ -576,9 +583,10 @@ async def main(args):
     ctx = ManualContext(args.connect, args.password, config_file.get("game"), config_file.get("player_name"))
     ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
 
-    ctx.item_table = config_file.get("items") or {}
-    ctx.location_table = config_file.get("locations") or {}
-    ctx.region_table = config_file.get("regions") or {}
+    ctx.item_table = config_file.get("items", {})
+    ctx.location_table = config_file.get("locations", {})
+    ctx.region_table = config_file.get("regions", {})
+    ctx.category_table = config_file.get("categories", {})
 
     if tracker_loaded:
         ctx.run_generator()

--- a/worlds/_manual/Options.py
+++ b/worlds/_manual/Options.py
@@ -13,7 +13,7 @@ manual_options = before_options_defined({})
 manual_options["filler_traps"] = FillerTrapPercent
 
 for category in category_table:
-    for option_name in category_table[category].get("requires_yaml", []):
+    for option_name in category_table[category].get("yaml_option", []):
         if option_name not in manual_options:
             manual_options[option_name] = type(option_name, (Toggle,), {"default": True})
 

--- a/worlds/_manual/Options.py
+++ b/worlds/_manual/Options.py
@@ -1,6 +1,7 @@
 from Options import FreeText, NumericOption, Toggle, DefaultOnToggle, Choice, TextChoice, Range, SpecialRange
 
 from .hooks.Options import before_options_defined, after_options_defined
+from .Data import category_table
 
 
 class FillerTrapPercent(Range):
@@ -10,5 +11,10 @@ class FillerTrapPercent(Range):
 manual_options = before_options_defined({})
 
 manual_options["filler_traps"] = FillerTrapPercent
+
+for category in category_table:
+    for option_name in category_table[category].get("requires_yaml", []):
+        if option_name not in manual_options:
+            manual_options[option_name] = type(option_name, (Toggle,), {"default": True})
 
 manual_options = after_options_defined(manual_options)

--- a/worlds/_manual/Regions.py
+++ b/worlds/_manual/Regions.py
@@ -1,5 +1,5 @@
 from BaseClasses import Entrance, MultiWorld, Region
-from worlds._manual.Helpers import is_category_enabled
+from .Helpers import is_category_enabled
 from .Data import region_table
 from .Locations import ManualLocation
 from worlds.AutoWorld import World
@@ -37,7 +37,7 @@ def create_regions(base: World, world: MultiWorld, player: int):
         for location in base.location_table:
             if "region" in location and location["region"] == region:
                 remove = False
-                for category in location["category"]:
+                for category in location.get("category", []):
                     if not is_category_enabled(world, player, category):
                         remove = True
                         break

--- a/worlds/_manual/Regions.py
+++ b/worlds/_manual/Regions.py
@@ -1,4 +1,5 @@
 from BaseClasses import Entrance, MultiWorld, Region
+from worlds._manual.Helpers import is_category_enabled
 from .Data import region_table
 from .Locations import ManualLocation
 from worlds.AutoWorld import World
@@ -20,9 +21,9 @@ regionMap["Manual"] = {
 
 regionMap = before_region_table_processed(regionMap)
 
-def create_regions(base: World, world: MultiWorld, player: int): 
+def create_regions(base: World, world: MultiWorld, player: int):
     # Create regions and assign locations to each region
-    for region in regionMap:  
+    for region in regionMap:
         if "connects_to" not in regionMap[region]:
             exit_array = None
         else:
@@ -32,9 +33,19 @@ def create_regions(base: World, world: MultiWorld, player: int):
         if not exit_array:
             exit_array = None
 
-        new_region = create_region(base, world, player, region, [
-            location["name"] for location in base.location_table if "region" in location and location["region"] == region
-        ], exit_array)
+        locations = []
+        for location in base.location_table:
+            if "region" in location and location["region"] == region:
+                remove = False
+                for category in location["category"]:
+                    if not is_category_enabled(world, player, category):
+                        remove = True
+                        break
+
+                if not remove:
+                    locations.append(location["name"])
+
+        new_region = create_region(base, world, player, region, locations, exit_array)
         world.regions += [new_region]
 
     menu = create_region(base, world, player, "Menu", None, ["Manual"])
@@ -51,7 +62,7 @@ def create_regions(base: World, world: MultiWorld, player: int):
 
 def create_region(base: World, world: MultiWorld, player: int, name: str, locations=None, exits=None):
     ret = Region(name, player, world)
-    
+
     if locations:
         for location in locations:
             loc_id = base.location_name_to_id.get(location, 0)

--- a/worlds/_manual/Rules.py
+++ b/worlds/_manual/Rules.py
@@ -177,8 +177,10 @@ def set_rules(base: World, world: MultiWorld, player: int):
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
 
+    used_location_names = []
     # Region access rules
     for region in regionMap.keys():
+        used_location_names.extend([l.name for l in world.get_region(region, player).locations])
         if region != "Menu":
             for exitRegion in world.get_region(region, player).exits:
                 def fullRegionCheck(state, region=regionMap[region]):
@@ -188,6 +190,9 @@ def set_rules(base: World, world: MultiWorld, player: int):
 
     # Location access rules
     for location in base.location_table:
+        if location["name"] not in used_location_names:
+            continue
+
         locFromWorld = world.get_location(location["name"], player)
 
         locationRegion = regionMap[location["region"]] if "region" in location else None

--- a/worlds/_manual/__init__.py
+++ b/worlds/_manual/__init__.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional
 
 from worlds.LauncherComponents import Component, SuffixIdentifier, components, Type, launch_subprocess
 
-from .Data import item_table, progressive_item_table, location_table, region_table
+from .Data import item_table, progressive_item_table, location_table, region_table, category_table
 from .Game import game_name, filler_item_name, starting_items
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location, location_name_groups
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, advancement_item_names, item_name_groups
@@ -17,7 +17,6 @@ from .Options import manual_options
 from .Helpers import is_option_enabled, get_option_value
 
 from BaseClasses import ItemClassification, Tutorial, Item
-from Fill import fill_restrictive
 from worlds.AutoWorld import World, WebWorld
 
 from .hooks.World import \
@@ -55,6 +54,7 @@ class ManualWorld(World):
 
     # These properties are set from the imports of the same name above.
     item_table = item_table
+    category_table = category_table
     progressive_item_table = progressive_item_table
     item_id_to_name = item_id_to_name
     item_name_to_id = item_name_to_id
@@ -291,6 +291,7 @@ class ManualWorld(World):
             'locations': self.location_name_to_location,
             # todo: extract connections out of mutliworld.get_regions() instead, in case hooks have modified the regions.
             'regions': region_table,
+            'categories': category_table,
 
         }
 

--- a/worlds/_manual/__init__.py
+++ b/worlds/_manual/__init__.py
@@ -107,14 +107,14 @@ class ManualWorld(World):
             if "count" in item:
                 item_count = int(item["count"])
 
-            if item_count == 0:
-                continue
-
             if "category" in item:
-                for category in item["category"]:
+                for category in item.get("category", []):
                     if not is_category_enabled(self.multiworld, self.player, category):
                         item_count = 0
                         break
+
+            if item_count == 0:
+                continue
 
             for i in range(item_count):
                 new_item = self.create_item(name)
@@ -168,7 +168,7 @@ class ManualWorld(World):
                     self.multiworld.push_precollected(starting_item)
                     pool.remove(starting_item)
 
-        extras = len(location_table) - len(pool) - 1 # subtracting 1 because of Victory; seems right
+        extras = len(self.multiworld.get_unfilled_locations(player=self.player)) - len(pool) - 1 # subtracting 1 because of Victory; seems right
 
         if extras > 0:
             trap_percent = get_option_value(self.multiworld, self.player, "filler_traps")

--- a/worlds/_manual/__init__.py
+++ b/worlds/_manual/__init__.py
@@ -14,7 +14,7 @@ from .Regions import create_regions
 from .Items import ManualItem
 from .Rules import set_rules
 from .Options import manual_options
-from .Helpers import is_option_enabled, get_option_value
+from .Helpers import is_category_enabled, is_option_enabled, get_option_value
 
 from BaseClasses import ItemClassification, Tutorial, Item
 from worlds.AutoWorld import World, WebWorld
@@ -109,6 +109,12 @@ class ManualWorld(World):
 
             if item_count == 0:
                 continue
+
+            if "category" in item:
+                for category in item["category"]:
+                    if not is_category_enabled(self.multiworld, self.player, category):
+                        item_count = 0
+                        break
 
             for i in range(item_count):
                 new_item = self.create_item(name)

--- a/worlds/_manual/data/categories.json
+++ b/worlds/_manual/data/categories.json
@@ -1,0 +1,5 @@
+{
+    "Example Logic only category": {
+        "hidden": true
+    }
+}

--- a/worlds/_manual/data/categories.json
+++ b/worlds/_manual/data/categories.json
@@ -1,5 +1,8 @@
 {
     "Example Logic only category": {
         "hidden": true
+    },
+    "Example Yaml-option category": {
+        "requires_yaml": ["DLC_enabled"]
     }
 }

--- a/worlds/_manual/data/categories.json
+++ b/worlds/_manual/data/categories.json
@@ -3,6 +3,6 @@
         "hidden": true
     },
     "Example Yaml-option category": {
-        "requires_yaml": ["DLC_enabled"]
+        "yaml_option": ["DLC_enabled"]
     }
 }


### PR DESCRIPTION
Adds a new categories.json, and adds two settings that can be configured with it:

- Client visibility.  This allows for logic-only categories that won't pollute the client
- Yaml Requirements.  This automatically creates yaml toggles that can removed the entire category (and everything in it) from generation.