### PR TITLE
Hooks for the new category stuff

### DIFF
--- a/worlds/_manual/Data.py
+++ b/worlds/_manual/Data.py
@@ -6,7 +6,7 @@ from .DataValidation import DataValidation, ValidationError
 
 from .hooks.Data import \
     after_load_item_file, after_load_progressive_item_file, \
-    after_load_location_file, after_load_region_file
+    after_load_location_file, after_load_region_file, after_load_category_file
 
 # blatantly copied from the minecraft ap world because why not
 def load_data_file(*args) -> dict:
@@ -32,6 +32,7 @@ item_table = after_load_item_file(item_table)
 progressive_item_table = after_load_progressive_item_file(progressive_item_table)
 location_table = after_load_location_file(location_table)
 region_table = after_load_region_file(region_table)
+category_table = after_load_category_file(category_table)
 
 # seed all of the tables for validation
 DataValidation.game_table = game_table

--- a/worlds/_manual/Helpers.py
+++ b/worlds/_manual/Helpers.py
@@ -1,5 +1,6 @@
 from BaseClasses import MultiWorld
 from .Data import category_table
+from .hooks.Helpers import before_is_category_enabled
 
 from typing import Union
 
@@ -8,13 +9,17 @@ def is_option_enabled(world: MultiWorld, player: int, name: str) -> bool:
 
 def get_option_value(world: MultiWorld, player: int, name: str) -> Union[int, dict]:
     option = getattr(world, name, None)
-    if option == None:
+    if option is None:
         return 0
 
     return option[player].value
 
 def is_category_enabled(world: MultiWorld, player: int, category_name: str) -> bool:
     """Check if a category has been disabled by a yaml option."""
+    hook_result = before_is_category_enabled(world, player, category_name)
+    if hook_result is not None:
+        return hook_result
+
     category_data = category_table.get(category_name, {})
     if "yaml_option" in category_data:
         for option_name in category_data["yaml_option"]:

--- a/worlds/_manual/hooks/Data.py
+++ b/worlds/_manual/hooks/Data.py
@@ -4,7 +4,7 @@
 def after_load_item_file(item_table: list) -> list:
     return item_table
 
-# NOTE: Progressive items are not currently supported in Manual. Once they are, 
+# NOTE: Progressive items are not currently supported in Manual. Once they are,
 #       this hook will provide the ability to meaningfully change those.
 def after_load_progressive_item_file(progressive_item_table: list) -> list:
     return progressive_item_table
@@ -18,3 +18,7 @@ def after_load_location_file(location_table: list) -> list:
 # if you need access to the locations after processing to add ids, etc., you should use the hooks in World.py
 def after_load_region_file(region_table: dict) -> dict:
     return region_table
+
+# called after the categories.json file has been loaded
+def after_load_category_file(category_table: dict) -> dict:
+    return category_table

--- a/worlds/_manual/hooks/Helpers.py
+++ b/worlds/_manual/hooks/Helpers.py
@@ -1,0 +1,8 @@
+from typing import Optional
+from BaseClasses import MultiWorld
+
+
+# Use this if you want to override the default behavior of is_option_enabled
+# Return True to enable the category, False to disable it, or None to use the default behavior
+def before_is_category_enabled(world: MultiWorld, player: int, category_name: str) -> Optional[bool]:
+    return None


### PR DESCRIPTION
Nice and simple.  

- A hook for loading the categories.json (Not sure why you'd ever want this, but no harm in providing it)
- A hook for enabling or disabling a category using more complex logic.  This will allow for people to use more complex option types than direct boolean mapping.